### PR TITLE
Update to use the langchain-neo4j package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 .streamlit/secrets.toml
 .env
+.venv
 .DS_Store
 .vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 tenacity!=8.4.0
-langchain==0.2.3
-openai==1.33.0
-langchain-openai==0.1.8
-neo4j-driver==5.21.0
+langchain==0.3.9
+openai==1.56.0
+langchain-openai==0.2.10
+neo4j==5.27.0
 streamlit==1.35.0
-langchainhub==0.1.18
-langchain-community==0.2.4
+langchainhub==0.1.21
+langchain-neo4j==0.1.1

--- a/solutions/agent-chat.py
+++ b/solutions/agent-chat.py
@@ -11,7 +11,7 @@ from langchain.tools import Tool
 # end::import_tool[]
 
 # tag::import_memory[]
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory
 # end::import_memory[]
 
 # tag::import_agent[]

--- a/solutions/agent-cypher.py
+++ b/solutions/agent-cypher.py
@@ -4,7 +4,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.prompts import PromptTemplate
 from langchain.schema import StrOutputParser
 from langchain.tools import Tool
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain import hub

--- a/solutions/agent-scoped.py
+++ b/solutions/agent-scoped.py
@@ -6,7 +6,7 @@ from langchain_core.prompts import PromptTemplate
 # end::import_prompt[]
 from langchain.schema import StrOutputParser
 from langchain.tools import Tool
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain import hub

--- a/solutions/agent-vector.py
+++ b/solutions/agent-vector.py
@@ -4,7 +4,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.prompts import PromptTemplate
 from langchain.schema import StrOutputParser
 from langchain.tools import Tool
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain import hub

--- a/solutions/agent.py
+++ b/solutions/agent.py
@@ -4,7 +4,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.prompts import PromptTemplate
 from langchain.schema import StrOutputParser
 from langchain.tools import Tool
-from langchain_community.chat_message_histories import Neo4jChatMessageHistory
+from langchain_neo4j import Neo4jChatMessageHistory
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain import hub

--- a/solutions/graph.py
+++ b/solutions/graph.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 # tag::graph[]
-from langchain_community.graphs import Neo4jGraph
+from langchain_neo4j import Neo4jGraph
 
 graph = Neo4jGraph(
     url=st.secrets["NEO4J_URI"],

--- a/solutions/tools/cypher-degrees.py
+++ b/solutions/tools/cypher-degrees.py
@@ -68,5 +68,6 @@ cypher_qa = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
     verbose=True,
-    cypher_prompt=cypher_prompt
+    cypher_prompt=cypher_prompt,
+    allow_dangerous_requests=True
 )

--- a/solutions/tools/cypher-degrees.py
+++ b/solutions/tools/cypher-degrees.py
@@ -1,4 +1,4 @@
-from langchain.chains import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain
 from langchain.prompts.prompt import PromptTemplate
 
 from solutions.llm import llm

--- a/solutions/tools/cypher-fewshot.py
+++ b/solutions/tools/cypher-fewshot.py
@@ -1,4 +1,4 @@
-from langchain.chains import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain
 from langchain.prompts.prompt import PromptTemplate
 
 from solutions.llm import llm

--- a/solutions/tools/cypher-fewshot.py
+++ b/solutions/tools/cypher-fewshot.py
@@ -47,5 +47,6 @@ cypher_qa = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
     verbose=True,
-    cypher_prompt=cypher_prompt
+    cypher_prompt=cypher_prompt,
+    allow_dangerous_requests=True
 )

--- a/solutions/tools/cypher-finetuned.py
+++ b/solutions/tools/cypher-finetuned.py
@@ -1,4 +1,4 @@
-from langchain.chains import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain
 # tag::import-prompt-template[]
 from langchain.prompts.prompt import PromptTemplate
 # end::import-prompt-template[]

--- a/solutions/tools/cypher-finetuned.py
+++ b/solutions/tools/cypher-finetuned.py
@@ -41,6 +41,7 @@ cypher_qa = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
     verbose=True,
-    cypher_prompt=cypher_prompt
+    cypher_prompt=cypher_prompt,
+    allow_dangerous_requests=True
 )
 # end::cypher-qa[]

--- a/solutions/tools/cypher-simple.py
+++ b/solutions/tools/cypher-simple.py
@@ -10,6 +10,7 @@ from langchain_neo4j import GraphCypherQAChain
 cypher_qa = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
-    verbose=True
+    verbose=True,
+    allow_dangerous_requests=True
 )
 # end::cypher-qa[]

--- a/solutions/tools/cypher-simple.py
+++ b/solutions/tools/cypher-simple.py
@@ -3,7 +3,7 @@ from llm import llm
 from graph import graph
 
 # tag::import[]
-from langchain_community.chains.graph_qa.cypher import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain
 # end::import[]
 
 # tag::cypher-qa[]

--- a/solutions/tools/cypher.py
+++ b/solutions/tools/cypher.py
@@ -1,4 +1,4 @@
-from langchain.chains import GraphCypherQAChain
+from langchain_neo4j import GraphCypherQAChain
 from langchain.prompts.prompt import PromptTemplate
 
 from solutions.llm import llm

--- a/solutions/tools/cypher.py
+++ b/solutions/tools/cypher.py
@@ -65,5 +65,6 @@ cypher_qa = GraphCypherQAChain.from_llm(
     llm,
     graph=graph,
     verbose=True,
-    cypher_prompt=cypher_prompt
+    cypher_prompt=cypher_prompt,
+    allow_dangerous_requests=True
 )

--- a/solutions/tools/vector.py
+++ b/solutions/tools/vector.py
@@ -3,7 +3,7 @@ from llm import llm, embeddings
 from graph import graph
 
 # tag::import_vector[]
-from langchain_community.vectorstores.neo4j_vector import Neo4jVector
+from langchain_neo4j import Neo4jVector
 # end::import_vector[]
 # tag::import_chain[]
 from langchain.chains.combine_documents import create_stuff_documents_chain


### PR DESCRIPTION
- Adds `langchain-neo4j` to requirements
- Updates all other requirements to their latest version
- Replaces `langchain_community` imports for `Neo4jVector`, `Neo4jGraph`, `Neo4jChatMessageHistory`, `GraphCypherQAChain` with their `langchain_neo4j` equivalents